### PR TITLE
Add license to gemspec

### DIFF
--- a/zonefile.gemspec
+++ b/zonefile.gemspec
@@ -8,6 +8,7 @@ SPEC = Gem::Specification.new do |s|
  s.email        = 'martin@internet.ao'
  s.rubyforge_project = 'zonefile'
  s.homepage     = 'http://zonefile.rubyforge.org/'
+ s.license      = 'MIT'
  s.platform     = Gem::Platform::RUBY
  s.summary      = 'BIND 8/9 Zonefile Reader and Writer'
  s.description  = "A library that can create, read, write, modify BIND compatible Zonefiles (RFC1035).\n"+


### PR DESCRIPTION
Add license to gemspec. With this addition, the license for new versions should show up on the library's [rubygems.org page](https://rubygems.org/gems/zonefile).

[refs #5]
